### PR TITLE
Add link icon to note heading

### DIFF
--- a/poznote-url-saver/popup.js
+++ b/poznote-url-saver/popup.js
@@ -308,7 +308,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const selectedFolderName = selectedFolder ? (selectedOption.dataset.path || selectedOption.text.replace(/^📁 /, '')) : '';
 
       const noteData = {
-        heading: `${pageTitle}${contentDescription ? ' - ' + contentDescription : ''}`,
+        heading: `🔗 ${pageTitle}${contentDescription ? ' - ' + contentDescription : ''}`,
         content: noteContent,
         tags: '',
         folder_name: selectedFolderName,


### PR DESCRIPTION
Add an emoji link icon in the title (🔗 title etc...).
This allows to find notes with URL links more quickly in the tree
<img width="316" height="275" alt="Capture d’écran 2026-02-03 143037" src="https://github.com/user-attachments/assets/13e86064-32dc-4ac3-bf60-786d56fe4cfd" />
