### PR TITLE
In app tab bar

### DIFF
--- a/src/css/tabs.css
+++ b/src/css/tabs.css
@@ -1,0 +1,258 @@
+/**
+ * In-App Tab Bar
+ *
+ * Shown at the top of #right_col when one or more notes are open as tabs.
+ * Behaves like browser tabs: sidebar navigation updates the active tab,
+ * "open in new tab" creates an additional tab.
+ */
+
+#app-tab-bar {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    padding: 6px 8px 0;
+    background: #fff;
+    border-bottom: 1px solid #e5e7eb;
+    overflow-x: auto;
+    flex-shrink: 0;
+    min-height: 38px;
+    /* Hide scrollbar but keep scrollability */
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+#app-tab-bar::-webkit-scrollbar {
+    display: none;
+}
+
+.app-tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 8px 5px 12px;
+    border-radius: 6px 6px 0 0;
+    background: #f3f4f6;
+    cursor: pointer;
+    max-width: 200px;
+    min-width: 80px;
+    border: 1px solid #e5e7eb;
+    border-bottom: none;
+    font-size: 0.825rem;
+    user-select: none;
+    flex-shrink: 0;
+    transition: background 0.1s ease;
+    position: relative;
+    bottom: -1px; /* overlap the bar's bottom border for active state */
+}
+
+.app-tab:hover {
+    background: #e9ecef;
+}
+
+.app-tab.active {
+    background: #fff;
+    border-color: #d1d5db;
+    font-weight: 500;
+    z-index: 1;
+}
+
+.app-tab-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: #374151;
+}
+
+.app-tab.active .app-tab-title {
+    color: #111827;
+}
+
+.app-tab-close {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 1px 4px;
+    color: #9ca3af;
+    font-size: 1rem;
+    line-height: 1;
+    border-radius: 3px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.app-tab-close:hover {
+    background: rgba(0, 0, 0, 0.08);
+    color: #374151;
+}
+
+/* ── Dark mode ── */
+
+[data-theme="dark"] #app-tab-bar {
+    background: #1e1e1e;
+    border-color: #3a3a3a;
+}
+
+[data-theme="dark"] .app-tab {
+    background: #252525;
+    border-color: #3a3a3a;
+}
+
+[data-theme="dark"] .app-tab:hover {
+    background: #2e2e2e;
+}
+
+/* Active tab: blue top accent + noticeably lighter bg + bright text */
+[data-theme="dark"] .app-tab.active {
+    background: #383838;
+    border-color: #4b5563;
+    border-top: 2px solid #007DB8;
+}
+
+[data-theme="dark"] .app-tab-title {
+    color: #7a7a7a;
+}
+
+[data-theme="dark"] .app-tab.active .app-tab-title {
+    color: #f0f0f0;
+}
+
+[data-theme="dark"] .app-tab-close {
+    color: #555;
+}
+
+[data-theme="dark"] .app-tab.active .app-tab-close {
+    color: #888;
+}
+
+[data-theme="dark"] .app-tab-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #e5e7eb;
+}
+
+/* ── Note actions (3-dot menu in sidebar) ── */
+
+.note-list-item {
+    display: flex;
+    align-items: center;
+    position: relative;
+}
+
+.note-list-item > a {
+    flex: 1;
+    min-width: 0; /* allow text truncation */
+}
+
+.note-actions {
+    position: relative;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+}
+
+.note-actions-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 3px 6px;
+    color: #9ca3af;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    line-height: 1;
+    display: none; /* hidden until parent row is hovered */
+    align-items: center;
+    justify-content: center;
+    transition: background 0.15s ease, color 0.15s ease;
+}
+
+.note-list-item:hover .note-actions-toggle,
+.note-actions-toggle.open {
+    display: flex;
+}
+
+.note-actions-toggle:hover {
+    background: rgba(107, 114, 128, 0.12);
+    color: #374151;
+}
+
+.note-actions-menu {
+    position: absolute;
+    right: 0;
+    top: 100%;
+    margin-top: 2px;
+    background: white;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+    min-width: 170px;
+    padding: 4px 0;
+    z-index: 10000;
+    display: none;
+}
+
+.note-actions-menu.show {
+    display: block;
+}
+
+.note-actions-menu-item {
+    padding: 8px 14px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: #374151;
+    font-size: 0.875rem;
+    transition: background-color 0.15s ease;
+    white-space: nowrap;
+}
+
+.note-actions-menu-item:hover {
+    background-color: #f3f4f6;
+}
+
+.note-actions-menu-item i {
+    font-size: 0.85em;
+    color: #6b7280;
+    width: 14px;
+    text-align: center;
+}
+
+.note-actions-menu-item:hover i {
+    color: #374151;
+}
+
+/* ── Note actions dark mode ── */
+
+[data-theme="dark"] .note-actions-toggle {
+    color: #555;
+}
+
+[data-theme="dark"] .note-actions-toggle:hover,
+[data-theme="dark"] .note-actions-toggle.open {
+    background: rgba(255, 255, 255, 0.08);
+    color: #aaa;
+}
+
+[data-theme="dark"] .note-actions-menu {
+    background: #2a2a2a;
+    border-color: #3a3a3a;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+}
+
+[data-theme="dark"] .note-actions-menu-item {
+    color: #d1d5db;
+}
+
+[data-theme="dark"] .note-actions-menu-item:hover {
+    background-color: #383838;
+}
+
+[data-theme="dark"] .note-actions-menu-item i {
+    color: #9ca3af;
+}
+
+[data-theme="dark"] .note-actions-menu-item:hover i {
+    color: #e5e7eb;
+}

--- a/src/index.php
+++ b/src/index.php
@@ -188,6 +188,7 @@ if ($width_value !== false && $width_value !== '' && $width_value !== '0' && $wi
     <link type="text/css" rel="stylesheet" href="css/drag-drop.css?v=<?php echo $v; ?>"/>
     <link type="text/css" rel="stylesheet" href="css/icons.css?v=<?php echo $v; ?>"/>
     <link type="text/css" rel="stylesheet" href="css/misc.css?v=<?php echo $v; ?>"/>
+    <link type="text/css" rel="stylesheet" href="css/tabs.css?v=<?php echo $v; ?>"/>
     <link rel="stylesheet" href="css/index-mobile.css?v=<?php echo $v; ?>" media="(max-width: 800px)">
     <link type="text/css" rel="stylesheet" href="css/modal-alerts.css?v=<?php echo $v; ?>"/>
     <link type="text/css" rel="stylesheet" href="css/modals/base.css?v=<?php echo $v; ?>"/>
@@ -972,6 +973,7 @@ $body_classes = trim($extra_body_classes);
 <script src="js/notes-list-events.js?v=<?php echo $v; ?>"></script>
 <script src="js/folder-icon.js?v=<?php echo $v; ?>"></script>
 <script src="js/kanban.js?v=<?php echo $v; ?>"></script>
+<script src="js/tabs.js?v=<?php echo $v; ?>"></script>
 
 <?php if ($note && is_numeric($note)): ?>
 <!-- Data for draft check (used by index-events.js) -->

--- a/src/js/note-loader-common.js
+++ b/src/js/note-loader-common.js
@@ -272,6 +272,12 @@ function loadNoteCommon(url, noteId, options) {
 
                                 currentRightColumn.innerHTML = rightColumn.innerHTML;
 
+                                // Update tab state and re-render tab bar
+                                if (window.tabManager) {
+                                    window.tabManager._onNoteLoaded(noteId);
+                                    window.tabManager.render();
+                                }
+
                                 // Clear Kanban view flags if requested
                                 if (options.clearKanbanFlags) {
                                     window._isKanbanViewActive = false;

--- a/src/js/notes.js
+++ b/src/js/notes.js
@@ -590,12 +590,17 @@ function openNoteInNewTab(noteId) {
         console.error('No note ID provided');
         return;
     }
-    
-    // Build URL with note ID and current workspace
+
+    if (window.tabManager) {
+        var titleEl = document.getElementById('inp' + noteId);
+        var title = (titleEl && titleEl.value.trim()) || 'Untitled';
+        window.tabManager.openInNewTab(noteId, title);
+        return;
+    }
+
+    // Fallback: open in a real browser tab
     var workspace = selectedWorkspace || getSelectedWorkspace();
     var url = 'index.php?workspace=' + encodeURIComponent(workspace) + '&note=' + encodeURIComponent(noteId);
-    
-    // Open in new tab
     window.open(url, '_blank');
 }
 

--- a/src/js/tabs.js
+++ b/src/js/tabs.js
@@ -1,0 +1,382 @@
+/**
+ * In-App Tab Bar
+ *
+ * Manages a browser-like tab bar inside #right_col.
+ * - First note opened auto-creates a tab.
+ * - Sidebar navigation updates the active tab's note.
+ * - "Open in new tab" creates an additional tab.
+ * - Tabs are persisted per-workspace in localStorage.
+ *
+ * Exposes window.tabManager for use by other modules.
+ */
+
+(function () {
+    'use strict';
+
+    // ── State ──────────────────────────────────────────────────────────────
+
+    /** @type {Array<{id: string, noteId: string, title: string}>} */
+    var tabs = [];
+
+    /** ID of the currently active tab, or null when no tabs exist. */
+    var activeTabId = null;
+
+    /**
+     * Set before calling loadNoteDirectly from switchToTab().
+     * Tells _onNoteLoaded that this is a tab-switch (not a sidebar navigation).
+     * @type {string|null}
+     */
+    var _pendingTabSwitch = null;
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    function _getWorkspace() {
+        if (window.selectedWorkspace) return window.selectedWorkspace;
+        try {
+            var params = new URLSearchParams(window.location.search);
+            return params.get('workspace') || 'default';
+        } catch (e) {
+            return 'default';
+        }
+    }
+
+    function _storageKey() {
+        return 'poznote_tabs_' + _getWorkspace();
+    }
+
+    function _saveToStorage() {
+        try {
+            localStorage.setItem(_storageKey(), JSON.stringify({
+                tabs: tabs,
+                activeTabId: activeTabId
+            }));
+        } catch (e) {
+            // Storage quota or private mode — silently ignore
+        }
+    }
+
+    function _loadFromStorage() {
+        try {
+            var raw = localStorage.getItem(_storageKey());
+            if (!raw) return null;
+            var data = JSON.parse(raw);
+            if (Array.isArray(data.tabs)) return data;
+        } catch (e) {}
+        return null;
+    }
+
+    function _findTabById(id) {
+        for (var i = 0; i < tabs.length; i++) {
+            if (tabs[i].id === id) return tabs[i];
+        }
+        return null;
+    }
+
+    function _indexById(id) {
+        for (var i = 0; i < tabs.length; i++) {
+            if (tabs[i].id === id) return i;
+        }
+        return -1;
+    }
+
+    function _generateId() {
+        return 'tab_' + Date.now() + '_' + Math.floor(Math.random() * 1000);
+    }
+
+    /** Read a note's current title from the DOM, fallback to stored value. */
+    function _readTitle(noteId, fallback) {
+        var el = document.getElementById('inp' + noteId);
+        if (el && el.value.trim()) return el.value.trim();
+        return fallback || 'Untitled';
+    }
+
+    function _buildUrl(noteId) {
+        var workspace = _getWorkspace();
+        return 'index.php?workspace=' + encodeURIComponent(workspace) +
+               '&note=' + encodeURIComponent(noteId);
+    }
+
+    // ── Render ─────────────────────────────────────────────────────────────
+
+    /**
+     * (Re-)create #app-tab-bar as the first child of #right_col.
+     * Called after every state change and after AJAX note loads.
+     */
+    function render() {
+        var rightCol = document.getElementById('right_col');
+        if (!rightCol) return;
+
+        // Remove existing tab bar
+        var existing = document.getElementById('app-tab-bar');
+        if (existing) existing.parentNode.removeChild(existing);
+
+        var bar = document.createElement('div');
+        bar.id = 'app-tab-bar';
+
+        tabs.forEach(function (tab) {
+            var el = document.createElement('div');
+            el.className = 'app-tab' + (tab.id === activeTabId ? ' active' : '');
+            el.setAttribute('data-tab-id', tab.id);
+
+            var titleSpan = document.createElement('span');
+            titleSpan.className = 'app-tab-title';
+            titleSpan.textContent = tab.title || 'Untitled';
+            titleSpan.title = tab.title || 'Untitled';
+
+            var closeBtn = document.createElement('button');
+            closeBtn.className = 'app-tab-close';
+            closeBtn.setAttribute('aria-label', 'Close tab');
+            closeBtn.textContent = '×';
+
+            el.appendChild(titleSpan);
+            el.appendChild(closeBtn);
+            bar.appendChild(el);
+        });
+
+        // Event delegation on the bar
+        bar.addEventListener('click', function (e) {
+            var closeBtn = e.target.closest('.app-tab-close');
+            if (closeBtn) {
+                var tabEl = closeBtn.closest('.app-tab');
+                if (tabEl) closeTab(tabEl.getAttribute('data-tab-id'));
+                return;
+            }
+            var tabEl = e.target.closest('.app-tab');
+            if (tabEl) switchToTab(tabEl.getAttribute('data-tab-id'));
+        });
+
+        // Prepend to right_col so it sits above the notecard
+        rightCol.insertBefore(bar, rightCol.firstChild);
+    }
+
+    // ── Public API ─────────────────────────────────────────────────────────
+
+    /**
+     * Called when "open in new tab" is clicked (from note toolbar or sidebar menu).
+     * Creates a new tab for the given note and makes it active.
+     * If the note is not currently displayed, loads it via AJAX.
+     */
+    function openInNewTab(noteId, title) {
+        noteId = String(noteId);
+        var newTab = { id: _generateId(), noteId: noteId, title: title || 'Untitled' };
+        tabs.push(newTab);
+        activeTabId = newTab.id;
+        _saveToStorage();
+        render();
+
+        // If the note isn't currently loaded in the right column, load it now.
+        // Use _pendingTabSwitch so _onNoteLoaded refreshes the title instead of
+        // creating yet another tab entry.
+        var isLoaded = !!document.getElementById('inp' + noteId);
+        if (!isLoaded) {
+            _pendingTabSwitch = newTab.id;
+            var url = _buildUrl(noteId);
+            if (typeof window.loadNoteDirectly === 'function') {
+                window.loadNoteDirectly(url, noteId, null, null);
+            }
+        }
+    }
+
+    /**
+     * Called when a tab is clicked.
+     * Sets _pendingTabSwitch so _onNoteLoaded knows not to update tab state,
+     * then loads the tab's note.
+     */
+    function switchToTab(tabId) {
+        var tab = _findTabById(tabId);
+        if (!tab) return;
+        if (tab.id === activeTabId) return; // already active
+
+        _pendingTabSwitch = tabId;
+
+        var url = _buildUrl(tab.noteId);
+        if (typeof window.loadNoteDirectly === 'function') {
+            window.loadNoteDirectly(url, tab.noteId, null, null);
+        } else {
+            // Fallback — full page navigation
+            window.location.href = url;
+        }
+    }
+
+    /**
+     * Called when a tab's × button is clicked.
+     * Removes the tab and switches to the closest neighbour.
+     * The last remaining tab cannot be closed.
+     */
+    function closeTab(tabId) {
+        if (tabs.length <= 1) return; // cannot close the last tab
+        var idx = _indexById(tabId);
+        if (idx === -1) return;
+
+        var wasActive = (tabId === activeTabId);
+        tabs.splice(idx, 1);
+
+        if (tabs.length === 0) {
+            // Last tab closed
+            activeTabId = null;
+            _saveToStorage();
+            render();
+            return;
+        }
+
+        if (wasActive) {
+            // Prefer left neighbour, else right
+            var newIdx = idx > 0 ? idx - 1 : 0;
+            var nextTab = tabs[newIdx];
+            activeTabId = nextTab.id;
+            _saveToStorage();
+            render();
+            // Load the tab's note
+            _pendingTabSwitch = nextTab.id;
+            var url = _buildUrl(nextTab.noteId);
+            if (typeof window.loadNoteDirectly === 'function') {
+                window.loadNoteDirectly(url, nextTab.noteId, null, null);
+            }
+        } else {
+            _saveToStorage();
+            render();
+        }
+    }
+
+    /**
+     * Hook called from loadNoteCommon immediately after innerHTML replacement.
+     * Decides whether to update the active tab's note (regular navigation)
+     * or just confirm the tab switch (tab click).
+     * @param {string|number} noteId
+     */
+    function _onNoteLoaded(noteId) {
+        noteId = String(noteId);
+
+        if (_pendingTabSwitch !== null) {
+            // Tab click or new-tab load — activate and refresh title from DOM
+            activeTabId = _pendingTabSwitch;
+            _pendingTabSwitch = null;
+            var switchedTab = _findTabById(activeTabId);
+            if (switchedTab && switchedTab.noteId === noteId) {
+                var freshTitle = _readTitle(noteId, switchedTab.title);
+                switchedTab.title = freshTitle;
+            }
+            _saveToStorage();
+            return;
+        }
+
+        // Regular sidebar navigation (or initial load via AJAX)
+        var title = _readTitle(noteId, 'Untitled');
+
+        if (activeTabId !== null) {
+            // Update the active tab to the new note
+            var tab = _findTabById(activeTabId);
+            if (tab) {
+                tab.noteId = noteId;
+                tab.title = title;
+            }
+        } else {
+            // No active tab — create the first tab
+            var newTab = { id: _generateId(), noteId: noteId, title: title };
+            tabs.push(newTab);
+            activeTabId = newTab.id;
+        }
+
+        _saveToStorage();
+    }
+
+    // ── Title live-update ──────────────────────────────────────────────────
+
+    document.addEventListener('input', function (e) {
+        if (!e.target.classList.contains('css-title')) return;
+        var noteId = e.target.id.replace('inp', '');
+        if (!noteId) return;
+
+        var changed = false;
+        tabs.forEach(function (tab) {
+            if (tab.noteId === noteId) {
+                tab.title = e.target.value.trim() || 'Untitled';
+                changed = true;
+            }
+        });
+
+        if (changed) {
+            _saveToStorage();
+            render();
+        }
+    });
+
+    // ── Initialisation ─────────────────────────────────────────────────────
+
+    function _init() {
+        // Read current note from page config
+        var currentNoteId = null;
+        try {
+            var configEl = document.getElementById('current-note-data');
+            if (configEl) {
+                var config = JSON.parse(configEl.textContent);
+                currentNoteId = config.noteId ? String(config.noteId) : null;
+            }
+        } catch (e) {}
+
+        // Try to restore from localStorage
+        var stored = _loadFromStorage();
+        if (stored && stored.tabs.length > 0) {
+            tabs = stored.tabs;
+            activeTabId = stored.activeTabId || null;
+
+            // Validate activeTabId is still in the list
+            if (activeTabId && !_findTabById(activeTabId)) {
+                activeTabId = tabs[0].id;
+            }
+
+            if (currentNoteId) {
+                // Find a tab whose noteId matches the current URL note
+                var matchingTab = null;
+                for (var i = 0; i < tabs.length; i++) {
+                    if (tabs[i].noteId === currentNoteId) {
+                        matchingTab = tabs[i];
+                        break;
+                    }
+                }
+
+                if (matchingTab) {
+                    // Make the matching tab active
+                    activeTabId = matchingTab.id;
+                } else if (activeTabId) {
+                    // Active tab's note doesn't match URL — update it
+                    var activeTab = _findTabById(activeTabId);
+                    if (activeTab) {
+                        activeTab.noteId = currentNoteId;
+                        activeTab.title = _readTitle(currentNoteId, 'Untitled');
+                    }
+                }
+            }
+
+            _saveToStorage();
+            render();
+            return;
+        }
+
+        // No stored tabs — create first tab from the current note
+        if (currentNoteId) {
+            var title = _readTitle(currentNoteId, 'Untitled');
+            tabs = [{ id: _generateId(), noteId: currentNoteId, title: title }];
+            activeTabId = tabs[0].id;
+            _saveToStorage();
+            render();
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', _init);
+    } else {
+        _init();
+    }
+
+    // ── Expose ─────────────────────────────────────────────────────────────
+
+    window.tabManager = {
+        openInNewTab: openInNewTab,
+        switchToTab: switchToTab,
+        closeTab: closeTab,
+        render: render,
+        _onNoteLoaded: _onNoteLoaded
+    };
+
+})();

--- a/src/notes_list.php
+++ b/src/notes_list.php
@@ -177,9 +177,17 @@ function displayFolderRecursive($folderId, $folderData, $depth, $con, $is_search
             }
         }
         
+        echo "<div class='note-list-item'>";
         echo "<a class='$noteClass $isSelected' href='$link' data-note-id='" . $noteDbId . "' data-note-db-id='" . $noteDbId . "' data-note-type='" . htmlspecialchars($noteType, ENT_QUOTES) . "'" . $linkedNoteIdAttr . " data-folder-id='$folderId' data-folder='$folderName' data-created='" . htmlspecialchars($row1['created'] ?? '', ENT_QUOTES) . "' data-updated='" . htmlspecialchars($row1['updated'] ?? '', ENT_QUOTES) . "' draggable='true' data-action='load-note'>";
         echo "<span class='note-title'>" . $noteIcon . htmlspecialchars($noteTitle, ENT_QUOTES) . "</span>";
         echo "</a>";
+        echo "<div class='note-actions'>";
+        echo "<button class='note-actions-toggle' data-action='toggle-note-actions-menu' data-note-id='" . $noteDbId . "' title='Note actions'><i class='fas fa-ellipsis-v'></i></button>";
+        echo "<div class='note-actions-menu' id='note-actions-menu-" . $noteDbId . "'>";
+        echo "<div class='note-actions-menu-item' data-action='open-note-new-tab' data-note-id='" . $noteDbId . "'><i class='fas fa-external-link'></i><span>Open in new tab</span></div>";
+        echo "</div>";
+        echo "</div>";
+        echo "</div>";
         echo "<div id=pxbetweennotes></div>";
     }
     
@@ -286,9 +294,17 @@ if (isset($uncategorized_notes) && !empty($uncategorized_notes) && empty($folder
             $noteIcon = '<i class="fas fa-link note-type-icon-inline"></i> ';
         }
         
+        echo "<div class='note-list-item'>";
         echo "<a class='$noteClass $isSelected' href='$link' data-note-id='" . $noteDbId . "' data-note-db-id='" . $noteDbId . "' data-note-type='" . htmlspecialchars($noteType, ENT_QUOTES) . "' data-folder-id='' data-folder='' data-created='" . htmlspecialchars($row1['created'] ?? '', ENT_QUOTES) . "' data-updated='" . htmlspecialchars($row1['updated'] ?? '', ENT_QUOTES) . "' draggable='true' data-action='load-note'>";
         echo "<span class='note-title'>" . $noteIcon . htmlspecialchars(($row1["heading"] ?: t('index.note.new_note', [], 'New note')), ENT_QUOTES) . "</span>";
         echo "</a>";
+        echo "<div class='note-actions'>";
+        echo "<button class='note-actions-toggle' data-action='toggle-note-actions-menu' data-note-id='" . $noteDbId . "' title='Note actions'><i class='fas fa-ellipsis-v'></i></button>";
+        echo "<div class='note-actions-menu' id='note-actions-menu-" . $noteDbId . "'>";
+        echo "<div class='note-actions-menu-item' data-action='open-note-new-tab' data-note-id='" . $noteDbId . "'><i class='fas fa-external-link'></i><span>Open in new tab</span></div>";
+        echo "</div>";
+        echo "</div>";
+        echo "</div>";
         echo "<div id=pxbetweennotes></div>";
     }
 }
@@ -316,9 +332,17 @@ if (isset($uncategorized_notes) && !empty($uncategorized_notes) && empty($folder
             $noteIcon = '<i class="fas fa-link note-type-icon-inline"></i> ';
         }
         
+        echo "<div class='note-list-item'>";
         echo "<a class='$noteClass $isSelected' href='$link' data-note-id='" . $noteDbId . "' data-note-db-id='" . $noteDbId . "' data-note-type='" . htmlspecialchars($noteType, ENT_QUOTES) . "' data-folder-id='' data-folder='' data-created='" . htmlspecialchars($row1['created'] ?? '', ENT_QUOTES) . "' data-updated='" . htmlspecialchars($row1['updated'] ?? '', ENT_QUOTES) . "' draggable='true' data-action='load-note'>";
         echo "<span class='note-title'>" . $noteIcon . htmlspecialchars(($row1["heading"] ?: t('index.note.new_note', [], 'New note')), ENT_QUOTES) . "</span>";
         echo "</a>";
+        echo "<div class='note-actions'>";
+        echo "<button class='note-actions-toggle' data-action='toggle-note-actions-menu' data-note-id='" . $noteDbId . "' title='Note actions'><i class='fas fa-ellipsis-v'></i></button>";
+        echo "<div class='note-actions-menu' id='note-actions-menu-" . $noteDbId . "'>";
+        echo "<div class='note-actions-menu-item' data-action='open-note-new-tab' data-note-id='" . $noteDbId . "'><i class='fas fa-external-link'></i><span>Open in new tab</span></div>";
+        echo "</div>";
+        echo "</div>";
+        echo "</div>";
         echo "<div id=pxbetweennotes></div>";
     }
 }


### PR DESCRIPTION
<img width="796" height="427" alt="image" src="https://github.com/user-attachments/assets/eb0cb2ca-cc03-48a2-beb4-8e28cd5b7ac5" />

- In-app tab bar: Replaces the "open in new tab" browser-tab behaviour with a tab bar rendered inside #right_col. The first note auto-creates a tab; sidebar navigation reuses the active tab; "open in new tab" creates an additional tab. Tabs are persisted per-workspace in localStorage and restored on page reload. Tab titles update live as notes are renamed.
- Note sidebar 3-dot menu: Adds a context menu to each note in the sidebar (matching the existing folder actions style), currently exposing an "Open in new tab" option.
- Dark mode: Active tab is visually distinguished with a blue top accent and higher-contrast text/background.
- Tab bar always visible: The tab bar remains visible even when only one tab is open

Have tested myself and I think it's all ok but could probably do with further testing to make sure.

## Another Claude vibe code