### PR TITLE
Enable JSX automatic transform by removing unnecessary React imports

### DIFF
--- a/excalidraw-build/src/ExcalidrawComponent.jsx
+++ b/excalidraw-build/src/ExcalidrawComponent.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useImperativeHandle, forwardRef } from 'react';
+import { useRef, useImperativeHandle, forwardRef } from 'react';
 import { Excalidraw, exportToCanvas } from '@excalidraw/excalidraw';
 
 const PoznoteExcalidraw = forwardRef((props, ref) => {

--- a/excalidraw-build/src/main.jsx
+++ b/excalidraw-build/src/main.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { Excalidraw, exportToCanvas } from '@excalidraw/excalidraw';
 import _ from 'lodash';


### PR DESCRIPTION
The project uses React 18 and Vite with @vitejs/plugin-react, which enables the automatic JSX runtime. The `import React from 'react'` statements in both ExcalidrawComponent.jsx and main.jsx are unnecessary and non-blocking but clutter the code. Removing them does not change behavior and aligns with React 17+ best practices. No cosmetic changes; this is a minor but genuine cleanup.