### PR TITLE
docs: add Kubernetes Helm installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,38 @@ docker compose up -d
 
 </details>
 
+<a id="kubernetes"></a>
+<details>
+<summary><strong>Kubernetes with Helm</strong></summary>
+
+#### Step 1: Prerequisite
+
+Install [Helm](https://helm.sh/docs/intro/install/) and make sure your Kubernetes context points to the cluster where you want to deploy Poznote.
+
+#### Step 2: Deploy Poznote
+
+Add the HelmForge chart repository:
+
+```bash
+helm repo add helmforge https://repo.helmforge.dev
+```
+
+Update your local chart index:
+
+```bash
+helm repo update
+```
+
+Install Poznote:
+
+```bash
+helm install poznote helmforge/poznote --namespace poznote --create-namespace
+```
+
+The Poznote Helm chart is maintained by the HelmForge community as a Kubernetes-native installation option. See the [HelmForge Poznote chart documentation](https://helmforge.dev/docs/charts/poznote) for values, persistence, service exposure, probes, security contexts, and other production-oriented settings.
+
+</details>
+
 > If you encounter installation issues, see the [Troubleshooting Guide](docs/TROUBLESHOOTING.md).
 
 ## Access


### PR DESCRIPTION
## Summary

Adds a Kubernetes installation option using the community-maintained HelmForge Helm chart for Poznote.

## Details

- Adds a "Kubernetes with Helm" installation section to the README.
- Documents the basic Helm repository setup and install command.
- Links to the HelmForge Poznote chart documentation for values and production-oriented settings.

## Validation

- Checked the README diff locally.
- Verified there are no replacement/control characters in the edited README.
- Verified the HelmForge chart repository and chart documentation URLs respond successfully.
- Validated the documented Helm flow with an isolated Helm repository config: repo add, repo update, helm show chart, and helm template.

Related discussion: https://github.com/timothepoznanski/poznote/discussions/1119