### PR TITLE
docs(openapi): suppress semgrep basic-auth finding with inline justification

### DIFF
--- a/src/api-docs/openapi.yaml
+++ b/src/api-docs/openapi.yaml
@@ -49,10 +49,10 @@ security:
 components:
   securitySchemes:
     BasicAuth:
-      type: http
-      # nosemgrep: yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
       # Deliberate: Basic Auth is protected by brute-force throttling, HTTPS is required,
       # and deployments can disable it entirely via OIDC_DISABLE_BASIC_AUTH.
+      # nosemgrep: yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+      type: http
       scheme: basic
       description: HTTP Basic Auth with global username/password. Include X-User-ID header for data endpoints.
     BearerAuth:

--- a/src/api-docs/openapi.yaml
+++ b/src/api-docs/openapi.yaml
@@ -50,6 +50,9 @@ components:
   securitySchemes:
     BasicAuth:
       type: http
+      # nosemgrep: yaml.openapi.security.use-of-basic-authentication.use-of-basic-authentication
+      # Deliberate: Basic Auth is protected by brute-force throttling, HTTPS is required,
+      # and deployments can disable it entirely via OIDC_DISABLE_BASIC_AUTH.
       scheme: basic
       description: HTTP Basic Auth with global username/password. Include X-User-ID header for data endpoints.
     BearerAuth:


### PR DESCRIPTION
## Summary

Follow-up to #1187, implementing the approach agreed in the review comments.

- Adds a line-scoped `nosemgrep` comment directly on the `scheme: basic` line in `src/api-docs/openapi.yaml`
- Does **not** use `.semgrepignore` (which would suppress all rules on the whole file)
- Inline justification documents the three mitigations: brute-force throttling, HTTPS requirement, and `OIDC_DISABLE_BASIC_AUTH` opt-out
- The spec stays accurate and the Swagger UI Authorize dialog retains the Basic option

The comment matches the exact format suggested by @timothepoznanski in https://github.com/timothepoznanski/poznote/pull/1187#issuecomment-5103205240.

## Test plan

- [ ] Run `semgrep --config=auto src/api-docs/openapi.yaml` — `use-of-basic-authentication` finding should be suppressed
- [ ] Confirm no other semgrep rules newly suppressed (only this one line annotated)
- [ ] Confirm OpenAPI spec is still valid YAML (`python3 -c "import yaml; yaml.safe_load(open('src/api-docs/openapi.yaml'))"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)