### PR TITLE
docs: add status badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,17 @@ Powerful note-taking without the hassle.
 
 <h3 align="center">
 A free, self-hosted, open-source alternative to Notion, Obsidian, Evernote, or OneNote.
-<h3 align="center">
+</h3>
+
+<p align="center">
+  <a href="https://github.com/timothepoznanski/poznote/releases"><img src="https://img.shields.io/github/v/release/timothepoznanski/poznote?label=release&color=1f6feb" alt="Latest release"></a>
+  <a href="https://github.com/timothepoznanski/poznote/pkgs/container/poznote"><img src="https://img.shields.io/badge/ghcr.io-poznote-2496ed?logo=docker&logoColor=white" alt="Docker image"></a>
+  <a href="https://github.com/timothepoznanski/poznote/blob/main/LICENCE"><img src="https://img.shields.io/github/license/timothepoznanski/poznote?color=44cc11" alt="License MIT"></a>
+  <a href="https://github.com/timothepoznanski/poznote/stargazers"><img src="https://img.shields.io/github/stars/timothepoznanski/poznote?color=f5b400" alt="GitHub stars"></a>
+  <a href="https://github.com/timothepoznanski/poznote/issues?q=is%3Aissue+is%3Aclosed"><img src="https://img.shields.io/github/issues-closed/timothepoznanski/poznote?label=issues%20closed&color=44cc11" alt="Closed issues"></a>
+  <a href="https://github.com/timothepoznanski/poznote/discussions"><img src="https://img.shields.io/github/discussions/timothepoznanski/poznote?label=discussions&logo=github&color=8957e5" alt="GitHub Discussions"></a>
+  <a href="https://demo.poznote.com"><img src="https://img.shields.io/badge/demo-live-brightgreen" alt="Live demo"></a>
+</p>
 
 <p align="center">
   <img src="images/pres1.png" alt="Poznote-light" width="100%">


### PR DESCRIPTION
Add a centered badge row under the tagline: release, GHCR image, license, stars, closed issues, discussions and live demo. Also fix the subtitle's closing tag, which was a second <h3> opening tag.