### PR TITLE
highlight format buttons when selected text has active formatting

### DIFF
--- a/src/public/css/toolbar.css
+++ b/src/public/css/toolbar.css
@@ -294,6 +294,16 @@ body:not(.has-background-image) .note-header {
     display: inline-flex;
 }
 
+.toolbar-btn.is-format-active {
+    background-color: var(--pz-accent-soft) !important;
+    color: var(--pz-accent) !important;
+}
+
+html[data-theme='dark'] .toolbar-btn.is-format-active {
+    background-color: var(--dm-accent-soft) !important;
+    color: var(--dm-accent) !important;
+}
+
 /* Note action buttons: visible by default, hidden during selection */
 .note-action-btn {
     display: inline-flex;

--- a/src/public/js/events-text-selection.js
+++ b/src/public/js/events-text-selection.js
@@ -467,6 +467,44 @@ function initTextSelectionHandlers() {
         });
     }
 
+    function updateFormatActiveStates(editableElement) {
+        var isMarkdown = editableElement && (
+            editableElement.classList.contains('markdown-editor') ||
+            editableElement.classList.contains('cm-content') ||
+            (editableElement.closest && editableElement.closest('.markdown-editor'))
+        );
+
+        var formats = [
+            { selector: '.btn-bold',          md: ['**', '**'],    rte: 'bold'          },
+            { selector: '.btn-italic',        md: ['*',  '*' ],    rte: 'italic'        },
+            { selector: '.btn-underline',     md: ['<u>', '</u>'], rte: 'underline'     },
+            { selector: '.btn-strikethrough', md: ['~~', '~~'],    rte: 'strikeThrough' },
+        ];
+
+        formats.forEach(function (fmt) {
+            var btn = document.querySelector(fmt.selector + '.show-on-selection');
+            if (!btn) return;
+
+            var isActive = false;
+            if (isMarkdown && typeof window.isMarkdownSelectionWrapped === 'function') {
+                isActive = window.isMarkdownSelectionWrapped(fmt.md[0], fmt.md[1]);
+                // Single * also matches inside **: treat italic as active only when not bold
+                if (fmt.md[0] === '*' && isActive) {
+                    isActive = !window.isMarkdownSelectionWrapped('**', '**');
+                }
+            } else {
+                try { isActive = document.queryCommandState(fmt.rte); } catch (e) { /* ignore */ }
+            }
+
+            btn.classList.toggle('is-format-active', isActive);
+        });
+    }
+
+    function clearFormatActiveStates() {
+        document.querySelectorAll('.btn-bold, .btn-italic, .btn-underline, .btn-strikethrough')
+            .forEach(function (btn) { btn.classList.remove('is-format-active'); });
+    }
+
     function handleSelectionChange() {
         clearTimeout(selectionTimeout);
         selectionTimeout = setTimeout(function () {
@@ -591,6 +629,7 @@ function initTextSelectionHandlers() {
                     for (var i = 0; i < noteActionButtons.length; i++) {
                         noteActionButtons[i].classList.add('hide-on-selection');
                     }
+                    updateFormatActiveStates(editableElement);
                     setMobileFormattingToolbarActive(true);
                 } else {
                     // Text selected but not in an editable area: hide everything
@@ -600,6 +639,7 @@ function initTextSelectionHandlers() {
                     for (var i = 0; i < noteActionButtons.length; i++) {
                         noteActionButtons[i].classList.add('hide-on-selection');
                     }
+                    clearFormatActiveStates();
                     setMobileFormattingToolbarActive(false);
                 }
             } else {
@@ -610,6 +650,7 @@ function initTextSelectionHandlers() {
                 for (var i = 0; i < noteActionButtons.length; i++) {
                     noteActionButtons[i].classList.remove('hide-on-selection');
                 }
+                clearFormatActiveStates();
                 setMobileFormattingToolbarActive(false);
             }
 

--- a/src/public/js/markdown-formatting.js
+++ b/src/public/js/markdown-formatting.js
@@ -975,8 +975,20 @@
         document.execCommand('insertHTML', false, styledText);
     }
 
+    function isMarkdownSelectionWrapped(prefix, suffix) {
+        var context = getCurrentMarkdownEditContext();
+        var editor = context.editor;
+        var offsets = context.offsets;
+        if (!editor || !offsets || offsets.start === offsets.end) return false;
+        var fullText = getMarkdownEditorValue(editor);
+        var before = fullText.slice(Math.max(0, offsets.start - prefix.length), offsets.start);
+        var after = fullText.slice(offsets.end, offsets.end + suffix.length);
+        return before === prefix && after === suffix;
+    }
+
     // Export functions
     window.isInMarkdownEditor = isInMarkdownEditor;
+    window.isMarkdownSelectionWrapped = isMarkdownSelectionWrapped;
     window.applyMarkdownBold = applyMarkdownBold;
     window.applyMarkdownItalic = applyMarkdownItalic;
     window.applyMarkdownStrikethrough = applyMarkdownStrikethrough;


### PR DESCRIPTION
 When a user selects text in a note, the formatting toolbar buttons (Bold, Italic, Underline, Strikethrough) now visually indicate whether the selected text already has that format applied — matching  
  the behaviour of most rich-text editors.                                                                                                                                                                
                                                                                                                                                                                                          
  - For RTE notes: uses `document.queryCommandState()` to detect the active format                                                                                                                        
  - For Markdown/CodeMirror notes: checks whether the selection is wrapped in the corresponding markdown syntax (`**`, `*`, `<u>…</u>`, `~~`)                                                             
  - Active buttons are highlighted using the existing theme accent colours (`--pz-accent-soft` / `--dm-accent-soft`), consistent with the rest of the UI                                                  
                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                              
                                                                                                                                                                                                          
  - `src/public/js/markdown-formatting.js` — exposes `isMarkdownSelectionWrapped(prefix, suffix)` to allow external detection of markdown inline formatting around the current selection                  
  - `src/public/js/events-text-selection.js` — adds `updateFormatActiveStates()` (called on each selection change) and `clearFormatActiveStates()` (called when selection is cleared)                     
  - `src/public/css/toolbar.css` — adds `.is-format-active` class with light and dark theme styles                                                                                                        
                                                                                                                                                                                                          
  ## Test plan                                                                                                                                                                                            
                                                                                                                                                                                                          
  - [ ] Select plain text → no format button is highlighted                                                                                                                                               
  - [ ] Select bold text (`**word**` in Markdown, or bold in RTE) → Bold button is highlighted                                                                                                            
  - [ ] Select italic text → Italic button is highlighted                                                                                                                                                 
  - [ ] Select underlined text → Underline button is highlighted
  - [ ] Select strikethrough text → Strikethrough button is highlighted                                                                                                                                   
  - [ ] Clear selection → all highlights are removed                                                                                                                                                      
  - [ ] Verify behaviour in both light and dark themes  